### PR TITLE
Multiple symbol fixes

### DIFF
--- a/src/layers/LayersPanel.jsx
+++ b/src/layers/LayersPanel.jsx
@@ -658,7 +658,7 @@ class LayersPanel extends Component {
 
         var ref = layer.refs.item;
         var el = ReactDOM.findDOMNode(ref);
-        this.refs['popup'].openForTarget(el, { layer: layer.props, layer_name: layer.props.name });
+        this.refs['popup'].openForTarget(el, { layer: layer.props, layer_name: layer.props.element.name() });
     };
 
     _cancelRenamingLayer = () => {

--- a/src/layers/LayersStore.ts
+++ b/src/layers/LayersStore.ts
@@ -128,12 +128,13 @@ export default class LayersStore extends CarbonStore<ILayersStoreState> {
             || props.hasOwnProperty("visible")
             || props.hasOwnProperty("stroke")
             || props.hasOwnProperty("fill")
+            || props.hasOwnProperty("flags")
         ) {
             let layers = this.state.layers;
 
             this._visitLayers(layers, (layer) => {
                 if (layer.id === elementId) {
-                    if (props.hasOwnProperty("name")) { layer.name = props.name; }
+                    if (props.hasOwnProperty("name") || props.hasOwnProperty("flags")) { layer.name = layer.element.displayName(); }
                     if (props.hasOwnProperty("stroke")) { layer.borderColor = this._displayColor(props.stroke, 'black'); }
                     if (props.hasOwnProperty("fill")) { layer.backgroundColor = this._displayColor(props.fill, 'white'); }
                     if (props.hasOwnProperty("visible")) { layer.visible = props.visible; }

--- a/src/shared/FlyoutButton.tsx
+++ b/src/shared/FlyoutButton.tsx
@@ -9,7 +9,7 @@ var idCounter = 0;
 interface IFlyoutButtonProps extends IReactElementProps{
     renderContent?:()=>ReactHTMLElement<any> | Element | React.ReactElement<any> | undefined | any;
     content?:any;
-    position?:any;
+    position?:{targetVertical?: "top" | "bottom", targetHorizontal?: "left" | "right"};
     showAction?:any;
     onOpened?:any;
     onClosed?:any;

--- a/src/shared/Pane.tsx
+++ b/src/shared/Pane.tsx
@@ -18,10 +18,15 @@ var _render_mods = function (base, mods, glue='_') {
 
 var _render_full_classname = function (base, props) {
     var cn = base;
-    if (props.classMods != null)
+    if (props.classMods != null) {
         cn += ' ' + _render_mods(base, props.classMods);
-    if (props.className != null)
+    }
+    if (props.disabled) {
+        cn += ' disabled';
+    }
+    if (props.className != null) {
         cn += ' ' + props.className;
+    }
 
     return cn;
 };
@@ -39,7 +44,7 @@ var _get_icon = function (props) {
                 icon = <i className={base_icon_cn + " " + props.icon}/>;
         }
     }
-    return icon
+    return icon;
 };
 
 var _get_caption = function (props) {
@@ -55,18 +60,24 @@ var _get_caption = function (props) {
     return caption
 };
 
-interface IPanelButtonProps extends IReactElementProps{
+interface IPanelButtonProps extends IReactElementProps<HTMLButtonElement>{
     icon?: string;
     label?: string;
+    disabled?: boolean;
 }
 
-export class PaneButton extends React.Component<any, void>  {
+export class PaneButton extends React.Component<IPanelButtonProps, void>  {
+    private onClick = e => {
+        if (!this.props.disabled) {
+            this.props.onClick(e);
+        }
+    }
     render() {
         var cn = _render_full_classname("pane-button", this.props);
         var caption = _get_caption(this.props);
         var icon = _get_icon(this.props);
         return (
-            <div className={cn} onClick={this.props.onClick}>
+            <div className={cn} onClick={this.onClick}>
                 {icon}
                 {caption}
             </div>
@@ -75,13 +86,22 @@ export class PaneButton extends React.Component<any, void>  {
 }
 
 export class PaneListItem extends React.Component<any, void>  {
+    private onClick = e => {
+        if (!this.props.disabled) {
+            this.props.onClick(e);
+        }
+        else {
+            e.stopPropagation();
+        }
+    }
+
     render() {
         var cn = _render_full_classname("pane-list__item", this.props);
         var icon    = _get_icon(this.props);
         var caption = _get_caption(this.props);
 
         return (
-            <p className={cn} onClick={this.props.onClick}>
+            <p className={cn} onClick={this.onClick}>
                 {icon}
                 {caption}
             </p>

--- a/src/styles/_common.less
+++ b/src/styles/_common.less
@@ -1,14 +1,3 @@
-// Bootstrap
-//@import "../../node_modules/bootstrap-less/bootstrap/variables.less";
-//@import "../../node_modules/bootstrap-less/bootstrap/mixins.less";
-//
-//@import "../../node_modules/bootstrap-less/bootstrap/modals.less";
-//@import "../../node_modules/bootstrap-less/bootstrap/button-groups.less";
-//@import "../../node_modules/bootstrap-less/bootstrap/buttons.less";
-//@import "../../node_modules/bootstrap-less/bootstrap/list-group.less";
-//@import "../../node_modules/bootstrap-less/bootstrap/navs.less";
-
-
 // Core variables and mixins
 @import 'less/mapple/mReset.less';
 

--- a/src/styles/less/CONSTANTS.less
+++ b/src/styles/less/CONSTANTS.less
@@ -150,6 +150,7 @@
 //topbar
 //@color_inactive_text  : #9b9fa2;
 @color_inactive_text  : rgba(255, 255, 255, 0.57);
+@inactive_icon_opacity: .5;
 
 
 //@sel_color     : @selection-color     ;

--- a/src/styles/less/_pane.less
+++ b/src/styles/less/_pane.less
@@ -7,11 +7,19 @@
     &-list__item {
         .cursor_pointer;
         .bbox;
-        &:hover {
+        &:hover:not(.disabled) {
             .bgfade(10);
         }
 
         .rnd2;
+
+        &.disabled{
+            color: @color_inactive_text;
+
+            .pane-icon {
+                opacity: @inactive_icon_opacity;
+            }
+        }
     }
 
     &-label{

--- a/src/workspace/__workspace.less
+++ b/src/workspace/__workspace.less
@@ -360,7 +360,6 @@
             }
         }
         &-panel {
-            .hide;
             .abs;
             top: 100%;
 
@@ -372,11 +371,7 @@
                 right: 0;
             }
 
-            .when_dropdown_open({
-                .bl;
-                .bgc(rgba(58, 49, 70, 0.95));
-            });
-
+            .bgc(rgba(58, 49, 70, 0.95));
 
             &-body {
                 padding: @air_half;

--- a/typings/custom.d.ts
+++ b/typings/custom.d.ts
@@ -16,7 +16,7 @@ declare interface ISimpleReactElementProps {
     style?: any;
     key?: any;
 }
-declare interface IReactElementProps extends ISimpleReactElementProps, React.DOMAttributes<HTMLElement>{
+declare interface IReactElementProps<T extends HTMLElement = HTMLElement> extends ISimpleReactElementProps, React.DOMAttributes<HTMLElement>{
 }
 
 declare type ImmutableRecord<T> = Immutable.Record.Instance<T>;


### PR DESCRIPTION
fixed #9, #41 
- added UIElement.flags property
- fixed display of symbol actions
- fixed double click in text tool
- fixed correct inline state when changing elements with a text tool
- mark as text, mark as background works inside the symbol as well
- layers panel shows displayName and edits real name
- context menus shows disabled elements
- contextbar menus changed to flyouts