### PR TITLE
fixed positioning on undo and redo, viewport stack on shift+z

### DIFF
--- a/src/layers/LayerItem.tsx
+++ b/src/layers/LayerItem.tsx
@@ -73,7 +73,7 @@ export default class LayerItem extends Component<LayerItemProps, LayerItemState>
         var artboard = app.activePage.getActiveArtboard();
         if (artboard) {
             Environment.view.ensureScale([artboard]);
-            Environment.view.ensureVisible([artboard]);
+            Environment.view.ensureCentered([artboard]);
             Selection.clearSelection();
         }
     }

--- a/src/layers/LayersPanel.tsx
+++ b/src/layers/LayersPanel.tsx
@@ -118,7 +118,7 @@ export default class LayersPanel extends StoreComponent<{}, LayersStoreState> {
         (app.activePage as IArtboardPage).setActiveArtboard(null);
         var artboards = app.activePage.children;
         Environment.view.ensureScale(artboards);
-        Environment.view.ensureVisible(artboards);
+        Environment.view.ensureCentered(artboards);
     }
 
     private renderBackButton() {


### PR DESCRIPTION
@Boorj fyi, shift+z goes to previous viewport position (scroll + zoom), alf+shift+z goes to the next one.
Position is memorized 1 second after scrolling/zooming ended.